### PR TITLE
Fix formatting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,9 @@ Python 2.6 or 2.7. You can install Boto using pip:
 ## Basic Configuration
 
 You need to set up your AWS security credentials before the sample code is able
-to connect to AWS. You can do this by creating a file named "credentials" at ~/.aws/ 
-(C:\Users\USER_NAME\.aws\ for Windows users) and saving the following lines in the file:
+to connect to AWS. You can do this by creating a file named "credentials" at
+`~/.aws/` (`C:\Users\USER_NAME\.aws\` for Windows users)
+and saving the following lines in the file:
 
     [default]
     aws_access_key_id = <your access key id>


### PR DESCRIPTION
The "\" + "." will escape a period instead of rendering the
literal characters "\" and ".".
